### PR TITLE
Use text/template instead of html/template

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"html/template"
+	"text/template"
 	"io"
 	"io/ioutil"
 	"log"

--- a/main_test.go
+++ b/main_test.go
@@ -9,8 +9,7 @@ import (
 )
 
 var deployYaml = strings.TrimSpace(`
-name: app-kustomize
-kustomize: . # directory relative to PWD!
+name: app
 dockerImages:
 - image: main
   context: .
@@ -28,5 +27,25 @@ func TestFixtureDockerImages(t *testing.T) {
 docker build -t main:latest .;
 docker build -t child:latest subdir;
 `, "\n")
-	assert.Equal(t, output.String(), expectedOutput)
+	assert.Equal(t, expectedOutput, output.String())
+}
+
+var blogYaml = strings.TrimSpace(`
+title: this-funny-thing
+date: 2020-01-01 10:00:00
+text: "Lorum ipsum dolor amet <strong>foobar</strong>!"
+
+`)
+
+func TestFixtureBlog(t *testing.T) {
+	output := bytes.NewBuffer(nil)
+
+	runTemplate([]byte(blogYaml), `<h1>{{html .title}}</h1><p>{{html .text}}</p>`, output)
+	expectedOutput := strings.TrimPrefix(`<h1>this-funny-thing</h1><p>Lorum ipsum dolor amet &lt;strong&gt;foobar&lt;/strong&gt;!</p>`, "\n")
+	assert.Equal(t, expectedOutput, output.String())
+	output.Reset()
+
+	runTemplate([]byte(blogYaml), `<h1>{{.title}}</h1><p>{{.text}}</p>`, output)
+	expectedOutput = strings.TrimPrefix(`<h1>this-funny-thing</h1><p>Lorum ipsum dolor amet <strong>foobar</strong>!</p>`, "\n")
+	assert.Equal(t, expectedOutput, output.String())
 }


### PR DESCRIPTION
# Before
Example input:

```yaml
data:
  foo: "<strong>bar</strong>"
```
```bash
yaml-templater input.yaml '{{ .data.foo }}'
```
will output:
```text
&lt;strong&gt;bar&lt;/strong&gt;
```

# After
Example input:
```yaml
data:
  foo: "<strong>bar</strong>"
```
```bash
yaml-templater input.yaml 'text: {{ .data.foo }} html: {{ html .data.foo }}'
```
will output:
```text
text: <strong>bar</strong>
html: &lt;strong&gt;bar&lt;/strong&gt;
```